### PR TITLE
Hibernate criteria query

### DIFF
--- a/src/main/java/ma/hibernate/dao/PhoneDaoImpl.java
+++ b/src/main/java/ma/hibernate/dao/PhoneDaoImpl.java
@@ -1,22 +1,52 @@
 package ma.hibernate.dao;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import ma.hibernate.model.Phone;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 
 public class PhoneDaoImpl extends AbstractDao implements PhoneDao {
+
     public PhoneDaoImpl(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
     @Override
     public Phone create(Phone phone) {
-        return null;
+        try (Session session = factory.openSession()) {
+            session.beginTransaction();
+            session.persist(phone);
+            session.getTransaction().commit();
+            return phone;
+        }
     }
 
     @Override
     public List<Phone> findAll(Map<String, String[]> params) {
-        return null;
+        try (Session session = factory.openSession()) {
+
+            CriteriaBuilder cb = session.getCriteriaBuilder();
+            CriteriaQuery<Phone> cq = cb.createQuery(Phone.class);
+            Root<Phone> root = cq.from(Phone.class);
+
+            List<Predicate> predicates = new ArrayList<>();
+
+            params.forEach((field, values) ->
+                    predicates.add(
+                            values.length == 1
+                                    ? cb.equal(root.get(field), values[0])
+                                    : root.get(field).in((Object[]) values)
+                    )
+            );
+
+            cq.where(cb.and(predicates.toArray(new Predicate[0])));
+            return session.createQuery(cq).getResultList();
+        }
     }
 }


### PR DESCRIPTION
Added Phone entity and DAO layer implementation.
Implemented create() and findAll() methods using Criteria API. findAll() supports dynamic filtering by any fields and multiple values via IN without using if/else.
Imports are ordered according to CustomImportOrder, all tests pass.